### PR TITLE
extra parameters and updated anticrash

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -27,8 +27,11 @@ stopped = threading.Event()
 started = threading.Event()
 param_event = threading.Event()
 Callback = WINFUNCTYPE(c_int, c_int, c_int, c_int, c_void_p)
+hsz=1
 pitch=2
 fluctuation=3
+rgh=4
+bth=5
 rate=6
 vlm=7
 lastindex=0
@@ -106,7 +109,7 @@ class eciThread(threading.Thread):
     param_event.set()
    elif msg.message == WM_COPYVOICE:
     dll.eciCopyVoice(handle, msg.wParam, 0)
-    for i in (rate, pitch, vlm, fluctuation):
+    for i in (rate, pitch, vlm, fluctuation, hsz, rgh, bth):
      vparams[i] = dll.eciGetVoiceParam(handle, 0, i)
     param_event.set()
    elif msg.message == WM_KILL:

--- a/eloquence.py
+++ b/eloquence.py
@@ -139,7 +139,9 @@ class SynthDriver(synthDriverHandler.SynthDriver):
   #text = text.encode('mbcs')
   text = normalizeText(text)
   text = resub(anticrash_res, text)
-  text = "`pp0 `vv%d %s" % (self.getVParam(_eloquence.vlm), text.replace('`', ' ')) #no embedded commands
+  if not self._backquoteVoiceTags:
+   text=text.replace('`', ' ')
+  text = "`pp0 `vv%d %s" % (self.getVParam(_eloquence.vlm), text) #no embedded commands
   text = pause_re.sub(r'\1 `p1\2\3', text)
   text = time_re.sub(r'\1:\2 \3', text)
   #if two strings are sent separately, pause between them. This might fix some of the audio issues we're having.
@@ -158,7 +160,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
  def terminate(self):
   _eloquence.terminate()
  _backquoteVoiceTags=False
- _ABRDICT=False
  def _get_backquoteVoiceTags(self):
   return self._backquoteVoiceTags
 


### PR DESCRIPTION
This pull request adds support for the head size, roughness, breathiness, and backquote voice tags settings to the synth driver. It also updates the built-in anticrash dictionary with the latest regexes I have crafted which seem to handle all currently known crash cases.