### PR TITLE
fixes loading of root dictionary

### DIFF
--- a/_eloquence.py
+++ b/_eloquence.py
@@ -79,9 +79,9 @@ class eciThread(threading.Thread):
   dll.eciSetDict(handle, self.dictionaryHandle)
   #0 = main dictionary
   if os.path.exists(os.path.join(os.path.dirname(eciPath), "main.dic")):
-   dll.eciLoadDict(handle, self.dictionaryHandle, 0, os.path.join(os.path.dirname(eciPath), "main.dic"))
+   dll.eciLoadDict(handle, self.dictionaryHandle, 0, os.path.join(os.path.dirname(eciPath), "main.dic").encode('mbcs'))
   if os.path.exists(os.path.join(os.path.dirname(eciPath), "root.dic")):
-   dll.eciLoadDict(handle, self.dictionaryHandle, 1, os.path.join(os.path.dirname(eciPath), "root.dic"))
+   dll.eciLoadDict(handle, self.dictionaryHandle, 1, os.path.join(os.path.dirname(eciPath), "root.dic").encode('mbcs'))
   params[9] = dll.eciGetParam(handle, 9)
   started.set()
   while True:

--- a/manifest.ini
+++ b/manifest.ini
@@ -1,7 +1,7 @@
 name = Eloquence
 summary = Eloquence Synthesizer
-version = 0.20191005.01
+version = 0.20200211.01
 description = This is the eloquence synthesizer for NVDA
 author = NVDA User
 url = https://github.com/pumper42nickel/eloquence_threshold
-lastTestedNVDAVersion=2025.4
+lastTestedNVDAVersion=2020.1


### PR DESCRIPTION
This pull request allows eloquence_threshold to properly load oot.dic and main.dic as placed in the same directory as eci.dll when installed. The change to unicode in python3 was causing ECI to get a utf-8 string for the path to the file and would generally refuse to load it. It likes mbcs.