### PR TITLE
Updated API reference URL

### DIFF
--- a/tts.txt
+++ b/tts.txt
@@ -1,4 +1,4 @@
-http://www.wizzardsoftware.com/docs/tts.pdf
+http://web.archive.org/web/20191125091344/http://www.wizzardsoftware.com/docs/tts.pdf
 
 IBM Text-to-Speech
 API Reference


### PR DESCRIPTION
This pull request updates the IBM text-to-Speech API reference URL to point to a Wayback Machine capture, because the API reference seems to have been removed from Wizzard Software's site, and now redirects to their home page.