### PR TITLE
Once again updated anticrash expressions

### DIFF
--- a/eloquence.py
+++ b/eloquence.py
@@ -17,7 +17,7 @@ import unicodedata
 minRate=40
 maxRate=150
 anticrash_res = {
- re.compile(r'\b(|\d+|\W+)?(|un|anti|re)c(ae|\xe6)sur', re.I): br'\1\2seizur',
+ re.compile(r'\b(|\d+|\W+)?(|un|anti|re|ultra|mis|cyber)c(ae|\xe6)sur', re.I): br'\1\2seizur',
  re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h ' \2 e",
  re.compile(r"\b(\w+[bdflmnrvzqh])(h[he]s)([bcdfgjklmnoprstw]\w+)\b", re.I): r"\1 \2\3",
  re.compile(r"([bcdfghjklmnpstvwxz])'([bdfhjklmnpstvxz']+)'([rtv][aeiou]?)", re.I): r"\1 \2 \3",

--- a/eloquence.py
+++ b/eloquence.py
@@ -17,15 +17,15 @@ import unicodedata
 minRate=40
 maxRate=150
 anticrash_res = {
- re.compile(r'\b(|\d+|\W+)?(|un|anti|re)c(ae|\xe6)sur', re.I): r'\1\2seizur',
+ re.compile(r'\b(|\d+|\W+)?(|un|anti|re)c(ae|\xe6)sur', re.I): br'\1\2seizur',
  re.compile(r"\b(|\d+|\W+)h'(r|v)[e]", re.I): r"\1h ' \2 e",
- re.compile(r"\b(\w+[bdflmnrvzqh])hes([bcdfgjklmnprtw]\w+)\b", re.I): r"\1 hes\2",
+ re.compile(r"\b(\w+[bdflmnrvzqh])(h[he]s)([bcdfgjklmnoprstw]\w+)\b", re.I): r"\1 \2\3",
+ re.compile(r"([bcdfghjklmnpstvwxz])'([bdfhjklmnpstvxz']+)'([rtv][aeiou]?)", re.I): r"\1 \2 \3",
  re.compile(r"(\d):(\d\d[snrt][tdh])", re.I): r"\1 \2",
- re.compile(r"h'([bdfjkpstvx']+)'([rtv][aeiou]?)", re.I): r"h \1 \2",
  re.compile(r"(re|un|non|anti)cosp", re.I): r"\1kosp",
- re.compile(r"(anti|non|re|un)caesure", re.I): r"\1ceasure",
+ re.compile(r"(anti|non|re|un|ultra|mis|cyber)caesure", re.I): r"\1ceasure",
  re.compile(r"(EUR[A-Z]+)(\d+)", re.I): r"\1 \2",
- re.compile(r"\b(|\d+|\W+)?t+z[s]che", re.I): r"\1tz sche"
+ re.compile(r"\b(|\d+|\W+|[A-Z]+|\d+)?t+z[s]che", re.I): r"\1tz sche"
 }
 
 pause_re = re.compile(r'([a-zA-Z])([.(),:;!?])( |$)')


### PR DESCRIPTION
This pull request strengthens the anticrash expressions considerably. Mostly ported from davidacm/NVDA-IBMTTS-Driver#30, with some improvements to the hes, apostrophe and cae crash expressions to catch more variants.