### PR TITLE
Make the add-on compatible with NVDA 2022.1

### DIFF
--- a/manifest.ini
+++ b/manifest.ini
@@ -4,4 +4,4 @@ version = 0.20210417.01
 description = This is the eloquence synthesizer for NVDA
 author = NVDA User
 url = https://github.com/pumper42nickel/eloquence_threshold
-lastTestedNVDAVersion=2021.1
+lastTestedNVDAVersion=2022.1


### PR DESCRIPTION
NVDA 2022.1 breaks compatibility of the add-ons. This pull request addresses the compatibility issue.