### PR TITLE
Update for NVDA 2023.1

### DIFF
--- a/manifest.ini
+++ b/manifest.ini
@@ -1,7 +1,7 @@
 name = Eloquence
 summary = Eloquence Synthesizer
-version = 0.220526.01
+version = 0.220526.02
 description = This is the eloquence synthesizer for NVDA
 author = NVDA User
 url = https://github.com/pumper42nickel/eloquence_threshold
-lastTestedNVDAVersion=2022.1
+lastTestedNVDAVersion=2023.1


### PR DESCRIPTION
Fixes #30 

Update the NVDA version to 2023.1. Untested.